### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "url": "https://lukeed.com"
   },
   "dependencies": {
-    "babel-plugin-transform-runtime": "^6.6.0",
+    "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.7.2"
+    "babel-register": "^6.8.0"
   }
 }


### PR DESCRIPTION
I ran into the following error when trying to use `fly-esnext`. When I updated the dependencies for this package it solved the problems.

``` bash
stack:
  - TypeError: Cannot read property 'error' of undefined
  -     at OptionManager.mergeOptions (~/ui-development/docs/node_modules/babel/node_modules/babel-core/lib/transformation/file/options/option-manager.js 126:28)
  -     at OptionManager.addConfig (~/ui-development/docs/node_modules/babel/node_modules/babel-core/lib/transformation/file/options/option-manager.js 107:10)
  -     at OptionManager.findConfigs (~/ui-development/docs/node_modules/babel/node_modules/babel-core/lib/transformation/file/options/option-manager.js 171:32)
  -     at OptionManager.init (~/ui-development/docs/node_modules/babel/node_modules/babel-core/lib/transformation/file/options/option-manager.js 229:12)
  -     at compile (~/ui-development/docs/node_modules/babel/node_modules/babel-core/lib/api/register/node.js 117:22)
  -     at normalLoader (~/ui-development/docs/node_modules/babel/node_modules/babel-core/lib/api/register/node.js 199:14)
  -     at Object.require.extensions.(anonymous function) [as .js] (~/ui-development/docs/node_modules/babel/node_modules/babel-core/lib/api/register/node.js 216:7)
  -     at Module.load (module.js 456:32)
  -     at tryModuleLoad (module.js 415:12)
  -     at Function.Module._load (module.js 407:3)
message: Cannot read property 'error' of undefined
```
