### PR TITLE
Update to Babel 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - '6'
+  - '5'
+  - '4'
+  - '0.12'
+  - 'iojs'
+
+git:
+  depth: 1
+
+branches:
+  only:
+    - master
+    - develop

--- a/flyfile.js
+++ b/flyfile.js
@@ -1,0 +1,8 @@
+// this will be included when fly imports plugins
+// before it reaches this file so this is this easiest
+// way to test it.
+require('./index.js')
+
+// `./test.js` has a async function function in it so
+// if it doesn't run then it means this package doesn't work
+module.exports.default = require('./test.js').default

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 require('babel-register')({
-	presets: ['es2015', 'stage-0'],
-	plugins: ['transform-runtime']
+  presets: [ 'latest' ],
+  plugins: [
+    "transform-runtime"
+  ],
+  babelrc: false
 });

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "fly-esnext",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Allow for ES6 and ES7 support throughout a Fly environment.",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "test": "echo \"No tests needed\" && exit 0"
+    "test": "fly"
   },
   "author": {
     "name": "Luke Edwards",
@@ -13,9 +13,12 @@
     "url": "https://lukeed.com"
   },
   "dependencies": {
-    "babel-plugin-transform-runtime": "^6.8.0",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.8.0"
+    "babel-plugin-transform-runtime": "^6.15.0",
+    "babel-preset-latest": "^6.14.0",
+    "babel-register": "^6.14.0",
+    "babel-runtime": "^6.11.6"
+  },
+  "devDependencies": {
+    "fly": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "url": "https://lukeed.com"
   },
   "dependencies": {
-    "babel-plugin-transform-runtime": "^6.6.0",
+    "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.7.2"
+    "babel-register": "^6.8.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+export default async function() {
+  console.log('it worked');
+}


### PR DESCRIPTION
I've been having issues with `fly-esnext` when I'm using babel 6+, and my own `.babelrc` config because it tries to pull in babel 6 dependencies into babel 5. 

I updated this package to use babel 6+ and also disabled the `babelrc` from getting merged. This way no user settings for babel will mess up the flyfile that's written in es6+.

I also added a very very simple test to ensure that this package is working as expected all versions of node. If you enable travis ci it will run on the same versions of node as the flyjs package does. Here are the passing tests https://travis-ci.org/tjbenton/fly-esnext/builds/161449482
